### PR TITLE
Add dockerfile for create execution environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Use a multi-stage build for a compact image
+
+# Stage 1: Build the Go application
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+
+# Copy go.mod and go.sum to download dependencies
+COPY go.mod .
+COPY go.sum .
+
+# Download Go modules
+RUN go mod download
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the application
+# CGO_ENABLED=0 is important for static compilation, making the binary self-contained
+# -o /app/list-manager-api specifies the output path and name of the binary
+# ./cmd/api specifies the main package to build
+RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /app/list-manager-api ./cmd/api
+
+# Stage 2: Create the final, compact image
+FROM alpine:latest
+
+WORKDIR /app
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/list-manager-api .
+
+# Expose the port the application listens on
+# Based on cmd/api/main.go, defaultPort is 8081
+EXPOSE 8085
+
+# Command to run the application
+# The application reads MONGO_URI and MONGO_DB_NAME from environment variables
+CMD ["./list-manager-api"] 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	defaultPort = 8081
+	defaultPort = 8085
 	mongoURI    = "mongodb://localhost:27017"
 	mongoDBName = "listmanager"
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,17 @@ services:
       - MongoDB_DATABASE=listmanager
     networks:
       - mongo-compose-network
+  api:
+    build: .
+    ports:
+      - "8085:8085"
+    environment:
+      MONGO_URI: mongodb://db:27017
+      MONGO_DB_NAME: listmanager
+    depends_on:
+      - db
+    networks:
+      - mongo-compose-network
 
 volumes:
   mongodb_data:


### PR DESCRIPTION
This commit introduces Docker containerization for the Go List Manager API. Key changes include:

- Dockerfile Creation: A multi-stage Dockerfile is added, building the Go application with golang:1.24-alpine into a compact alpine:latest image.
- main.go Update: The default application port in cmd/api/main.go is updated to 8085.
- docker-compose.yml Configuration: A new api service is added, building from the Dockerfile, mapping host port 8085 to container port 8085. It also sets MONGO_URI and MONGO_DB_NAME environment variables for MongoDB connection and declares a dependency on the db service.

This enables easy setup and execution of the entire application stack (Go API, MongoDB, and Mongo Express) using docker-compose up --build -d.